### PR TITLE
Add Lovelace editor for waterfall history card

### DIFF
--- a/horizontal-waterfall-history-card.js
+++ b/horizontal-waterfall-history-card.js
@@ -20,10 +20,6 @@ const fireEvent = (node, type, detail, options) => {
   return event;
 };
 
-const lit = window.Lit || window.litElement || {};
-const LitElementBase = lit.LitElement || window.LitElement;
-const html = lit.html || window.html;
-const css = lit.css || window.css;
 
 class waterfallHistoryCard extends HTMLElement {
   // FIX: Hardcoded default domain icons
@@ -562,7 +558,20 @@ console.info(
   'color: white; font-weight: bold; background: dimgray'
 );
 
-if (LitElementBase && html && css && !customElements.get('waterfall-history-card-editor')) {
+const registerWaterfallHistoryCardEditor = () => {
+  if (customElements.get('waterfall-history-card-editor')) {
+    return true;
+  }
+
+  const litLib = window.litElement || window.Lit || {};
+  const LitElementBase = litLib.LitElement || window.LitElement;
+  const html = litLib.html || window.html;
+  const css = litLib.css || window.css;
+
+  if (!LitElementBase || !html || !css) {
+    return false;
+  }
+
   class WaterfallHistoryCardEditor extends LitElementBase {
     static get properties() {
       return {
@@ -1111,4 +1120,20 @@ if (LitElementBase && html && css && !customElements.get('waterfall-history-card
   }
 
   customElements.define('waterfall-history-card-editor', WaterfallHistoryCardEditor);
+  return true;
+};
+
+if (!registerWaterfallHistoryCardEditor()) {
+  let attempts = 0;
+  const retryRegistration = () => {
+    if (registerWaterfallHistoryCardEditor()) {
+      return;
+    }
+    if (attempts < 5) {
+      attempts += 1;
+      setTimeout(retryRegistration, 1000);
+    }
+  };
+  retryRegistration();
+  window.loadCardHelpers?.().then(() => registerWaterfallHistoryCardEditor());
 }


### PR DESCRIPTION
## Summary
- expose `getConfigElement` and register a dedicated Lovelace editor
- add a tabbed editor experience covering general, entity, and threshold settings
- support tri-state entity overrides and threshold color editing with color picker integration

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d121de34a8832ebcf4f111f90d41a1