### PR TITLE
Add configurable language support with German translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ entities:
 | `show_current`| `boolean` | `true`  | Show the current value next to the entity name.                             |
 | `show_icons`  | `boolean` | `true`  | Show entity icons globally. Can be overridden per entity.                   |
 | `compact`     | `boolean` | `false` | Use smaller font sizes and spacing.                                         |
+| `language`    | `string`  | `"auto"` | Language for built-in labels. Supports `auto`, `en`, `de`, `fr` (and synonyms such as `english`, `deutsch`, etc.). |
 
 ---
 
@@ -97,6 +98,8 @@ entities:
   - entity: sensor.kitchen_temp
     hours: 6            # custom history window
 ```
+
+To force the card to German regardless of the Home Assistant UI language, set `language: deutsch` (synonyms such as `german` or the short code `de` work as well). The default `auto` follows the UI language when available.
 
 
 ### Styling with Card-mod


### PR DESCRIPTION
## Summary
- add German translations alongside existing English and French strings
- allow the card language to be chosen via a new `language` option with synonyms
- update documentation to explain the new language option and how to force German

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d12a81b3e0832e9e41db093e1aa994