### PR TITLE
Prevent editor re-render loop on hass updates

### DIFF
--- a/horizontal-waterfall-history-card.js
+++ b/horizontal-waterfall-history-card.js
@@ -617,11 +617,22 @@ class WaterfallHistoryCardEditor extends HTMLElement {
     this._config = { entities: [] };
     this._selectedTab = 0;
     this._shouldFocusSelectedTab = false;
+    this._hasRendered = false;
   }
 
   set hass(hass) {
     this._hass = hass;
-    this.render();
+
+    if (!this._hasRendered) {
+      this.render();
+      return;
+    }
+
+    this.shadowRoot
+      ?.querySelectorAll('ha-entity-picker[data-field="entity"]')
+      .forEach((picker) => {
+        picker.hass = hass;
+      });
   }
 
   setConfig(config) {
@@ -1145,6 +1156,8 @@ class WaterfallHistoryCardEditor extends HTMLElement {
     this.shadowRoot.querySelectorAll('.remove-entity').forEach((button) => {
       button.addEventListener('click', (ev) => this._removeEntity(ev));
     });
+
+    this._hasRendered = true;
   }
 
   _entityPickerChanged(ev) {


### PR DESCRIPTION
## Summary
- prevent the card editor from rebuilding on every hass update
- keep entity pickers in sync with hass without losing focus

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d1663bf438832ea422602f1fbede42