### PR TITLE
Allow per-entity icon overrides

### DIFF
--- a/horizontal-waterfall-history-card.js
+++ b/horizontal-waterfall-history-card.js
@@ -330,12 +330,17 @@ class waterfallHistoryCard extends HTMLElement {
         const name = entityConfig.name || entity.attributes.friendly_name || entityId;
                 // FIX: derive icon per-entity if provided on the state
         // FIX: resolve icon per entity with domain fallback
-        let icon = null;
-        if (entity.attributes && entity.attributes.icon) {
-          icon = entity.attributes.icon;
-        } else {
-          const domain = entityId.split('.')[0];
-          icon = this.DEFAULT_DOMAIN_ICONS[domain] || 'mdi:bookmark';
+        let icon = entityConfig.icon;
+        if (typeof icon === 'string') {
+          icon = icon.trim();
+        }
+        if (!icon) {
+          if (entity.attributes && entity.attributes.icon) {
+            icon = entity.attributes.icon;
+          } else {
+            const domain = entityId.split('.')[0];
+            icon = this.DEFAULT_DOMAIN_ICONS[domain] || 'mdi:bookmark';
+          }
         }
         // FIX: resolve show_icons safely even if this.config is not yet defined
         const globalShowIcons = (this && this.config && this.config.show_icons !== undefined) ? this.config.show_icons : true;
@@ -915,6 +920,12 @@ class WaterfallHistoryCardEditor extends HTMLElement {
                     data-field="name"
                     data-entity-index="${index}"
                     value="${entity.name ?? ''}"
+                  ></ha-textfield>
+                  <ha-textfield
+                    label="Icon (z. B. mdi:thermometer)"
+                    data-field="icon"
+                    data-entity-index="${index}"
+                    value="${entity.icon ?? ''}"
                   ></ha-textfield>
                   <ha-textfield
                     label="Stunden"


### PR DESCRIPTION
## Summary
- allow overriding entity icons directly from the card configuration
- surface a text field in the entity editor to define manual icons

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d173c83eb0832e84e75c88bb651063