### PR TITLE
Prevent settings dialog closing when changing select value

### DIFF
--- a/horizontal-waterfall-history-card.js
+++ b/horizontal-waterfall-history-card.js
@@ -1380,8 +1380,11 @@ class WaterfallHistoryCardEditor extends HTMLElement {
         select.value = select.dataset.value;
       }
       select.addEventListener('selected', (ev) => this._valueChanged(ev));
-      select.addEventListener('closed', (ev) => this._valueChanged(ev));
       select.addEventListener('value-changed', (ev) => this._valueChanged(ev));
+      // Prevent the dialog from closing when the select menu closes.
+      select.addEventListener('closed', (ev) => {
+        ev.stopPropagation();
+      });
     });
 
     this.shadowRoot.querySelectorAll('ha-textfield[data-threshold-field]').forEach((input) => {


### PR DESCRIPTION
## Summary
- stop propagating the `closed` event emitted by `ha-select`
- keep relying on the existing `selected` / `value-changed` handlers to update config values

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d1859d6ee4832eb2e1ff8d1d365a14