### PR TITLE
Allow zero gap for dot segments

### DIFF
--- a/horizontal-waterfall-history-card.js
+++ b/horizontal-waterfall-history-card.js
@@ -605,6 +605,7 @@ class waterfallHistoryCard extends HTMLElement {
     const spacingValue = entityConfig.segment_spacing ?? this.config.segment_spacing ?? 0;
     const parsedSpacing = Number(spacingValue);
     const gap = Number.isFinite(parsedSpacing) ? Math.max(0, parsedSpacing) : 0;
+    const isZeroGap = gap === 0;
 
     const defaults = {
       bar: { width: '100%', height: '100%', radius: '2px', aspectRatio: 'auto' },
@@ -615,7 +616,7 @@ class waterfallHistoryCard extends HTMLElement {
         aspectRatio: 'auto',
       },
       dot: {
-        width: '55%',
+        width: isZeroGap ? '100%' : '55%',
         height: 'auto',
         radius: '9999px',
         aspectRatio: '1 / 1',


### PR DESCRIPTION
## Summary
- ensure dot segment appearance checks for zero spacing
- expand dot width to 100% when segment spacing is zero to remove residual gaps

## Testing
- No tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d18d92be0c832e81d9a8fe9c404c3a