### PR TITLE
Allow UI height down to 1px

### DIFF
--- a/horizontal-waterfall-history-card.js
+++ b/horizontal-waterfall-history-card.js
@@ -1005,7 +1005,7 @@ class WaterfallHistoryCardEditor extends HTMLElement {
         <ha-textfield
           label="Höhe (px)"
           type="number"
-          min="10"
+          min="1"
           step="1"
           data-field="height"
           value="${this._config.height ?? ''}"


### PR DESCRIPTION
## Summary
- allow the height input to accept values down to 1px in the editor

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d18f07b3e0832e8afef9857f64a29a